### PR TITLE
Prevent redeclaring tap function

### DIFF
--- a/cli/includes/helpers.php
+++ b/cli/includes/helpers.php
@@ -108,18 +108,20 @@ function should_be_sudo()
     }
 }
 
-/**
- * Tap the given value.
- *
- * @param  mixed  $value
- * @param  callable  $callback
- * @return mixed
- */
-function tap($value, callable $callback)
-{
-    $callback($value);
+if (! function_exists('tap')) {
+    /**
+     * Tap the given value.
+     *
+     * @param  mixed  $value
+     * @param  callable  $callback
+     * @return mixed
+     */
+    function tap($value, callable $callback)
+    {
+        $callback($value);
 
-    return $value;
+        return $value;
+    }
 }
 
 /**


### PR DESCRIPTION
I was getting an error when running gulp on a project. Specifically "PHP Fatal error:  Cannot redeclare tap() (previously declared in /home/vince/.config/composer/vendor/illuminate/support/helpers.php:816) in /home/vince/.config/composer/vendor/cpriego/valet-ubuntu/cli/includes/helpers.php on line 123".

Checking to see if the function exists before redeclaring works great.