### PR TITLE
nginx installation for ppa:nginx/stable

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -37,7 +37,7 @@ class Nginx
      */
     function install()
     {
-        $this->ubuntu->ensureInstalled('nginx-core');
+        $this->ubuntu->ensureInstalled('nginx');
 
         $this->installConfiguration();
         $this->installServer();


### PR DESCRIPTION
there are no package "nginx-core" in ppa:nginx/stable

```sh
$ curl -s http://ppa.launchpad.net/nginx/stable/ubuntu/dists/xenial/main/binary-i386/Packages.gz | gzip -d | grep Package
Package: nginx
Package: nginx-full
Package: nginx-light
Package: nginx-doc
Package: nginx-extras
Package: nginx-common
Package: libnginx-mod-http-auth-pam
Package: libnginx-mod-http-geoip
Package: libnginx-mod-http-image-filter
Package: libnginx-mod-http-lua
Package: libnginx-mod-http-ndk
Package: libnginx-mod-http-perl
Package: libnginx-mod-http-xslt-filter
Package: libnginx-mod-mail
Package: libnginx-mod-stream
Package: libnginx-mod-http-cache-purge
Package: libnginx-mod-http-echo
Package: libnginx-mod-http-fancyindex
Package: libnginx-mod-http-headers-more-filter
Package: libnginx-mod-http-subs-filter
Package: libnginx-mod-http-uploadprogress
Package: libnginx-mod-http-upstream-fair
Package: libnginx-mod-nchan
Package: libnginx-mod-http-dav-ext
```